### PR TITLE
obliterate Kurt Tussle and provide config option for his existence

### DIFF
--- a/dZoneManager/dZoneManager.cpp
+++ b/dZoneManager/dZoneManager.cpp
@@ -1,3 +1,4 @@
+#include "dZoneManager.h"
 #include "Game.h"
 #include "dCommonVars.h"
 #include "dZoneManager.h"
@@ -55,6 +56,7 @@ void dZoneManager::Initialize(const LWOZONEID& zoneID) {
     Game::logger->Log("dZoneManager", "Zone prepared in: %llu ms\n", (endTime - startTime));
 
 	VanityUtilities::SpawnVanity();
+    HacksocZoneChanges(zoneID.GetMapID());
 }
 
 dZoneManager::~dZoneManager() {
@@ -229,4 +231,14 @@ std::vector<Spawner*> dZoneManager::GetSpawnersInGroup(std::string group) {
 	}
 
 	return spawnersInGroup;
+}
+
+void dZoneManager::HacksocZoneChanges(const LWOMAPID mapID) {
+	switch (mapID) {
+        case 1200:
+		    // disable Kurt Tussle, preventing access to Nexus Tower
+            if (Game::config->GetValue("block_nexus_tower") == "1") {
+                dZoneManager::RemoveSpawner(4123168661387);
+            }
+	}
 }

--- a/dZoneManager/dZoneManager.h
+++ b/dZoneManager/dZoneManager.h
@@ -42,6 +42,8 @@ public:
 	Entity* GetZoneControlObject() { return m_ZoneControlObject; }
 
 private:
+    void HacksocZoneChanges(const LWOMAPID mapID);
+
     static dZoneManager* m_Address; //Singleton
 	Zone* m_pZone;
 	LWOZONEID m_ZoneID;

--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -50,3 +50,6 @@ solo_racing=0
 
 # Disables the anti-speedhack system. If you get kicked randomly you might want to disable this, as it might just be lag
 disable_anti_speedhack=0
+
+# HackSoc event feature: prevent access to Nexus Tower by killing the quest giver that opens it
+block_nexus_tower=1


### PR DESCRIPTION
does as it says on the tin
(verified it builds, haven't verified it works)

edit `worldconfig.ini` to `disable_nexus_tower=0` for group event

(also commit that back to `resources/` so it doesn't get disabled again on rebuild lmao)

normal progress will likely be slightly fucked while this is active, because in live things were moved to Nexus Tower when it was built
those things haven't been moved back, so some things the game may expect to be possible won't be